### PR TITLE
Rule exceptions for `fp/no-mutation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 1.0.11
+
+Updated configuration for `fp/no-mutation`:
+- Allowed mutations coming from CommonJS syntax
+- Allowed object mutations for `.propTypes` and `.defaultProps`
+
+
 ## 1.0.10
 
 Updated grouping rules for `simple-import-sort/sort`.

--- a/dist/main.js
+++ b/dist/main.js
@@ -83,7 +83,13 @@ module.exports = {
     "fp/no-loops": 2,
     "fp/no-mutating-assign": 2,
     "fp/no-mutating-methods": 1,
-    "fp/no-mutation": 2,
+    "fp/no-mutation": [2, {
+      "commonjs": true,
+      "exceptions": [
+        {"property": "propTypes"},
+        {"property": "defaultProps"}
+      ]
+    }],
     "fp/no-proxy": 2,
     "fp/no-this": 2,
     "fp/no-valueof-field": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bence.a.toth/eslint-config",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "An opinionated and extensive ESLint configuration for React applications",
   "main": "dist/main.js",
   "author": "Bence A. Toth <tothab@gmail.com>",


### PR DESCRIPTION
Updated configuration for `fp/no-mutation`:
- Allowed mutations coming from CommonJS syntax
- Allowed object mutations for `.propTypes` and `.defaultProps`
